### PR TITLE
Add nix build derivation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .direnv/
 .envrc
+result
 dist
 dist-*
 cabal-dev

--- a/flake.nix
+++ b/flake.nix
@@ -1,9 +1,14 @@
 {
-  description = "Dev environment for lastpass-tui";
+  description = "Package build and dev environment for lastpass-tui";
   outputs = { self, nixpkgs }: {
-    # setup the devShell for x86_64-linux.
+    # setup derivation for x86_64-linux
+    defaultPackage.x86_64-linux =
+      with import nixpkgs { system = "x86_64-linux"; };
+      haskell.packages.ghc884.callCabal2nix "lastpass-tui" self {};
+    
+    # setup devShell for x86_64-linux.
     devShell.x86_64-linux =
-      with nixpkgs.legacyPackages.x86_64-linux;
+      with import nixpkgs { system = "x86_64-linux"; };
       let
         inherit (lib) makeLibraryPath;
         hs = haskell.packages.ghc884;

--- a/lastpass-tui.cabal
+++ b/lastpass-tui.cabal
@@ -22,7 +22,7 @@ common shared-properties
 executable lpt
   import:              shared-properties
   build-depends:       base == 4.*
-                     , brick >= 0.55
+                     , brick
                      , lpt-lib
   main-is:             Main.hs
   hs-source-dirs:      src
@@ -31,7 +31,7 @@ executable lpt
 library lpt-lib
   import:              shared-properties
   build-depends:       base == 4.*
-                     , brick >= 0.55
+                     , brick
   exposed-modules:     Main
   hs-source-dirs:      src, src/Lpt
   ghc-options:         -Wall


### PR DESCRIPTION
Add a nix build derivation to the `flake.nix` so you can build a local derivation of the executable through nix using the `nix build` command.