### PR TITLE
No longer run CI on push to master

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,12 +1,6 @@
 name: Haskell CI
 
 on:
-  push:
-    branches: [ master ]
-    paths:
-    - '**.cabal'
-    - 'src/**'
-    - 'test/**'
   pull_request:
     branches: [ master ]
     paths:

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -1,12 +1,6 @@
 name: Nix build
 
 on:
-  push:
-    branches: [ master ]
-    paths:
-    - '**.cabal'
-    - 'src/**'
-    - 'test/**'
   pull_request:
     branches: [ master ]
     paths:


### PR DESCRIPTION
CI no longer again when you push to master meaning it doesn't rerun the CIs from a pull request