### PR TITLE
Render vault item list with detailed view on the home page

### DIFF
--- a/lastpass-tui.cabal
+++ b/lastpass-tui.cabal
@@ -38,12 +38,14 @@ library lpt-lib
                      , regex
                      , text
                      , unordered-containers
+                     , vector
                      , vty
   exposed-modules:     CLI
                      , Parse.Encode
                      , Parse.Decode
                      , Parse.Types
                      , UI.Core
+                     , UI.Home
                      , UI.Login
                      , UI.Types
   hs-source-dirs:      src, src/Lpt

--- a/src/Lpt/CLI.hs
+++ b/src/Lpt/CLI.hs
@@ -125,7 +125,8 @@ getJsonItems password = idList >>= traverse (getJsonItem password)
   where idList = parseIds <$> showItems
 
 getJsonItem :: String -> String -> IO String
-getJsonItem pass iden = readProcess "lpass" ["show", "--json", iden] pass
+getJsonItem password iden =
+  readProcess "lpass" ["show", "--json", iden] password
 
 getItems :: String -> IO [Either String Item]
 getItems password = map parseItem <$> getJsonItems password

--- a/src/Lpt/Parse/Encode.hs
+++ b/src/Lpt/Parse/Encode.hs
@@ -1,10 +1,21 @@
+{- |
+   Module      : Parse.Encode
+   License     : GNU GPL, version 3 or above
+   Maintainer  : skykanin <3789764+skykanin@users.noreply.github.com>
+   Stability   : alpha
+   Portability : portable
+
+Provides encoding functions the Item type
+-}
 module Parse.Encode
   ( fromItem
   , write
   )
 where
 
-import qualified Data.HashMap.Strict           as H
+import           Data.HashMap.Strict            ( HashMap
+                                                , toList
+                                                )
 import           Data.List                      ( intercalate )
 import           Parse.Types
 
@@ -32,6 +43,6 @@ fromItem (MkComplex (Complex _ name _ note)) =
   [("Name", name), ("", fromMap note)]
 
 -- | Convert complex hashmap value to writable string format
-fromMap :: H.HashMap String String -> String
-fromMap = concatMap format . H.toList
+fromMap :: HashMap String String -> String
+fromMap = concatMap format . toList
   where format (key, val) = key ++ ":" ++ val ++ "\n"

--- a/src/Lpt/UI/Core.hs
+++ b/src/Lpt/UI/Core.hs
@@ -18,9 +18,6 @@ import           Brick.Focus
 import           Brick.Forms
 import           Brick.Main
 import           Brick.Types
-import           Brick.Widgets.Border
-import           Brick.Widgets.Center
-import           Brick.Widgets.Core
 import qualified Brick.Widgets.Edit            as E
 import           Brick.Util                     ( on )
 import           CLI                            ( User(..)
@@ -29,18 +26,19 @@ import           CLI                            ( User(..)
 import           Control.Monad.IO.Class         ( liftIO )
 import qualified Graphics.Vty                  as V
 import           Graphics.Vty.Input.Events
+import           UI.Home
 import           UI.Login
 import           UI.Types                       ( Name(..)
                                                 , TuiState(..)
                                                 )
-
+-- | Application entry point
 tui :: IO ()
 tui = do
   initialState <- buildInitialState
   _            <- defaultMain tuiApp initialState
   return ()
 
-
+-- | Top level application definition
 tuiApp :: App TuiState e Name
 tuiApp = App { appDraw         = drawTui
              , appChooseCursor = focusRingCursor focus

--- a/src/Lpt/UI/Core.hs
+++ b/src/Lpt/UI/Core.hs
@@ -49,7 +49,7 @@ tuiApp = App { appDraw         = drawTui
 
 focus :: TuiState -> FocusRing Name
 focus (Login (form, _)) = formFocus form
-focus (Home  _        ) = focusRing [HomeBox]
+focus (Home  _        ) = focusRing [HomeList]
 
 theMap :: AttrMap
 theMap = attrMap
@@ -65,8 +65,7 @@ buildInitialState = pure . Login $ (loginForm (User "" ""), "")
 
 drawTui :: TuiState -> [Widget Name]
 drawTui (Login tuple) = uncurry drawLoginPage $ tuple
-drawTui (Home string) =
-  pure . center . hLimit 50 . borderWithLabel (str "Home") . str $ string
+drawTui (Home  list ) = drawHomepage list
 
 handleTuiEvent :: TuiState -> BrickEvent Name e -> EventM Name (Next TuiState)
 handleTuiEvent state event = case state of
@@ -76,10 +75,10 @@ handleTuiEvent state event = case state of
       EvKey KEnter [] -> handleLogin form vtye
       _ -> handleFormEvent (VtyEvent vtye) form >>= continue . wrap
     _ -> continue state
-  Home _ -> case event of
+  Home list -> case event of
     VtyEvent vtye -> case vtye of
       EvKey KEsc [] -> exitThenHalt state
-      _             -> continue state
+      _             -> handleHomepage list vtye
     _ -> continue state
 
 exitThenHalt :: TuiState -> EventM Name (Next TuiState)

--- a/src/Lpt/UI/Core.hs
+++ b/src/Lpt/UI/Core.hs
@@ -19,6 +19,7 @@ import           Brick.Forms
 import           Brick.Main
 import           Brick.Types
 import qualified Brick.Widgets.Edit            as E
+import qualified Brick.Widgets.List            as L
 import           Brick.Util                     ( on )
 import           CLI                            ( User(..)
                                                 , endSession
@@ -54,10 +55,11 @@ focus (Home  _        ) = focusRing [HomeList]
 theMap :: AttrMap
 theMap = attrMap
   V.defAttr
-  [ (E.editAttr          , V.white `on` V.black)
-  , (E.editFocusedAttr   , V.black `on` V.yellow)
-  , (invalidFormInputAttr, V.white `on` V.red)
-  , (focusedFormInputAttr, V.black `on` V.yellow)
+  [ (E.editAttr               , V.white `on` V.black)
+  , (E.editFocusedAttr        , V.black `on` V.yellow)
+  , (invalidFormInputAttr     , V.white `on` V.red)
+  , (focusedFormInputAttr     , V.black `on` V.yellow)
+  , (L.listSelectedFocusedAttr, V.black `on` V.yellow)
   ]
 
 buildInitialState :: IO TuiState

--- a/src/Lpt/UI/Home.hs
+++ b/src/Lpt/UI/Home.hs
@@ -1,0 +1,60 @@
+{- |
+   Module      : UI.Home
+   License     : GNU GPL, version 3 or above
+   Maintainer  : skykanin <3789764+skykanin@users.noreply.github.com>
+   Stability   : alpha
+   Portability : portable
+
+UI module dealing with the home page rendering and event handling
+-}
+module UI.Home
+  ( buildHomepage
+  , drawHomepage
+  , handleHomepage
+  )
+where
+
+import           Brick.Main
+import           Brick.Types
+import           Brick.Widgets.Border           ( border )
+import           Brick.Widgets.Core             ( hLimit
+                                                , str
+                                                , vBox
+                                                )
+import           Brick.Widgets.List             ( List
+                                                , list
+                                                , handleListEvent
+                                                , renderList
+                                                )
+import           CLI                            ( User(..)
+                                                , getItems
+                                                )
+import           Control.Monad.IO.Class         ( liftIO )
+import           Data.Either                    ( rights )
+import           Data.Text                      ( unpack )
+import           Data.Vector                    ( fromList )
+import           Graphics.Vty.Input.Events      ( Event )
+import           Parse.Types                    ( Item
+                                                , getId
+                                                , getName
+                                                )
+import           UI.Types                       ( Name(..)
+                                                , TuiState(..)
+                                                )
+
+drawHomepage :: List Name Item -> [Widget Name]
+drawHomepage = pure . border . hLimit 50 . renderList renderElement True
+
+renderElement :: Bool -> Item -> Widget Name
+renderElement focus item =
+  highlight . vBox . map (\f -> str (f item)) $ [getId, getName]
+  where highlight = if focus then border else id
+
+buildHomepage :: User -> Event -> EventM Name (Next TuiState)
+buildHomepage (User _ passwd) vtye = do
+  items <- liftIO $ getItems (unpack passwd)
+  let itemList = list HomeList (fromList (rights items)) 5
+  handleHomepage itemList vtye
+
+handleHomepage :: List Name Item -> Event -> EventM Name (Next TuiState)
+handleHomepage items vtye = handleListEvent vtye items >>= continue . Home

--- a/src/Lpt/UI/Home.hs
+++ b/src/Lpt/UI/Home.hs
@@ -31,15 +31,9 @@ import           Brick.Widgets.List             ( List
                                                 , handleListEvent
                                                 , renderList
                                                 )
-import           CLI                            ( User(..)
-                                                , getItems
-                                                )
-import           Control.Monad.IO.Class         ( liftIO )
-import           Data.Either                    ( rights )
 import           Data.HashMap.Strict            ( elems
                                                 , keys
                                                 )
-import           Data.Text                      ( unpack )
 import           Data.Vector                    ( fromList )
 import           Graphics.Vty.Input.Events      ( Event )
 import qualified Parse.Types                   as T
@@ -100,11 +94,9 @@ noteKeys = ["Id", "Name", "Group", "Note"]
 complexKeys :: [String]
 complexKeys = ["Id", "Name", "Group"]
 
-buildHomepage :: User -> Event -> EventM Name (Next TuiState)
-buildHomepage (User _ passwd) vtye = do
-  items <- liftIO $ getItems (unpack passwd)
-  let itemList = list HomeList (fromList (rights items)) 5
-  handleHomepage itemList vtye
+buildHomepage :: [Item] -> Event -> EventM Name (Next TuiState)
+buildHomepage items vtye = handleHomepage itemList vtye
+  where itemList = list HomeList (fromList items) 5
 
 handleHomepage :: List Name Item -> Event -> EventM Name (Next TuiState)
 handleHomepage items vtye = handleListEvent vtye items >>= continue . Home

--- a/src/Lpt/UI/Login.hs
+++ b/src/Lpt/UI/Login.hs
@@ -31,6 +31,7 @@ import           Control.Monad.IO.Class         ( liftIO )
 import           Data.Maybe                     ( fromJust )
 import           Graphics.Vty.Input.Events      ( Event )
 import           System.Exit                    ( ExitCode(..) )
+import           UI.Home                        ( buildHomepage )
 import           UI.Types                       ( Name(..)
                                                 , TuiState(..)
                                                 )
@@ -62,7 +63,7 @@ handleLogin form vtye = if not $ field `elem` [EmailField, PasswdField]
     form'    <- handleFormEvent (VtyEvent vtye) form
     exitcode <- liftIO $ startSession (formState form')
     case exitcode of
-      ExitSuccess   -> continue (Home "This is the main menu!")
+      ExitSuccess   -> buildHomepage (formState form) vtye
       ExitFailure _ -> continue (Login (form', "Wrong username or password"))
   where field = fromJust . focusGetCurrent . formFocus $ form
 

--- a/src/Lpt/UI/Login.hs
+++ b/src/Lpt/UI/Login.hs
@@ -5,7 +5,7 @@
    Stability   : alpha
    Portability : portable
 
-UI module dealing with the login page drawing and event handling
+UI module dealing with the login page rendering and event handling
 -}
 module UI.Login
   ( drawLoginPage
@@ -42,6 +42,7 @@ drawLoginPage form errStr =
 
 fix :: Widget Name -> [Widget Name]
 fix = pure . center . setAvailableSize (50, 10) . borderWithLabel (str "Login")
+
 loginForm :: User -> Form User e Name
 loginForm =
   let label s w =

--- a/src/Lpt/UI/Login.hs
+++ b/src/Lpt/UI/Login.hs
@@ -24,11 +24,14 @@ import           Brick.Widgets.Center
 import           Brick.Widgets.Core
 import           CLI                            ( User(..)
                                                 , email
+                                                , getItems
                                                 , passwd
                                                 , startSession
                                                 )
 import           Control.Monad.IO.Class         ( liftIO )
+import           Data.Either                    ( rights )
 import           Data.Maybe                     ( fromJust )
+import           Data.Text                      ( unpack )
 import           Graphics.Vty.Input.Events      ( Event )
 import           System.Exit                    ( ExitCode(..) )
 import           UI.Home                        ( buildHomepage )
@@ -63,7 +66,9 @@ handleLogin form vtye = if not $ field `elem` [EmailField, PasswdField]
     form'    <- handleFormEvent (VtyEvent vtye) form
     exitcode <- liftIO $ startSession (formState form')
     case exitcode of
-      ExitSuccess   -> buildHomepage (formState form) vtye
+      ExitSuccess -> do
+        items <- liftIO . getItems . unpack . _passwd . formState $ form
+        buildHomepage (rights items) vtye
       ExitFailure _ -> continue (Login (form', "Wrong username or password"))
   where field = fromJust . focusGetCurrent . formFocus $ form
 

--- a/src/Lpt/UI/Types.hs
+++ b/src/Lpt/UI/Types.hs
@@ -20,9 +20,14 @@ import           CLI                            ( User )
 import           Graphics.Vty.Input.Events      ( Event )
 import           Parse.Types                    ( Item )
 
+type LoginForm = Form User Event Name
+type Error = String
+
+type ItemList = List Name Item
+
 data TuiState =
-    Login (Form User Event Name, String)
-  | Home (List Name Item)
+    Login (LoginForm, Error)
+  | Home ItemList
 
 data Name =
     EmailField

--- a/src/Lpt/UI/Types.hs
+++ b/src/Lpt/UI/Types.hs
@@ -15,16 +15,18 @@ module UI.Types
 where
 
 import           Brick.Forms
+import           Brick.Widgets.List             ( List )
 import           CLI                            ( User )
 import           Graphics.Vty.Input.Events      ( Event )
+import           Parse.Types                    ( Item )
 
 data TuiState =
     Login (Form User Event Name, String)
-  | Home String
+  | Home (List Name Item)
 
 data Name =
     EmailField
   | PasswdField
   | ShowField
-  | HomeBox
+  | HomeList
   deriving (Eq, Ord, Show)


### PR DESCRIPTION
Now renders a scrollable vault item list on the left with a detailed view of the item info on the right hand side. Closes #22 

![alt text](https://i.imgur.com/fbJBTt9.png)
