### PR TITLE
Support user login cache

### DIFF
--- a/src/Lpt/CLI.hs
+++ b/src/Lpt/CLI.hs
@@ -12,6 +12,7 @@
 -- Provides all the commands wrapping the lastpass-cli
 module CLI
   ( User (..),
+    checkLoginStatus,
     email,
     passwd,
     endSession,

--- a/src/Lpt/UI/Event.hs
+++ b/src/Lpt/UI/Event.hs
@@ -64,13 +64,17 @@ handleTuiEvent :: TuiState -> BrickEvent Name e -> EventM Name (Next TuiState)
 handleTuiEvent state event = case state of
   LoginPage (form, _) -> case event of
     VtyEvent vtye -> case vtye of
-      EvKey KEsc [] -> exitThenHalt state
+      EvKey (KChar 'q') [MCtrl] -> halt state
       EvKey KEnter [] -> handleLogin form vtye
       _ -> handleFormEvent (VtyEvent vtye) form >>= continue . wrap
     _ -> continue state
   HomePage il lf ii fif -> case event of
     VtyEvent vtye -> case vtye of
-      EvKey KEsc [] -> exitThenHalt state
+      EvKey (KChar 'q') xs ->
+        case xs of
+          [MCtrl] -> halt state
+          [MCtrl, MAlt] -> exitThenHalt state
+          _ -> continue state
       EvKey KRight [] -> handleHomepage vtye il False ii fif
       EvKey KLeft [] -> handleHomepage vtye il True ii fif
       EvKey (KChar 'c') [MCtrl] ->


### PR DESCRIPTION
This support is added through the lastpass-cli which itself supports user login cache. You no longer need to login every time you reopen the TUI. To invalidate the cache exit the TUI with `Ctrl + Alt + q` instead of `Ctrl + q`.